### PR TITLE
解决项目在idea-dart-analysis会出现大量错误的问题

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+analyzer:
+  strong-mode:
+    implicit-casts: true
+    implicit-dynamic: true
+  errors:
+    mixin_inherits_from_not_object: ignore

--- a/lib/test/DemoMixins.dart
+++ b/lib/test/DemoMixins.dart
@@ -17,7 +17,7 @@ abstract class Base {
   }
 }
 
-class A extends Base {
+mixin A on Base {
   a() {
     print("A.a()");
     //super.a();
@@ -29,7 +29,7 @@ class A extends Base {
   }
 }
 
-class A2 extends Base {
+mixin A2 on Base {
   a() {
     print("A2.a()");
     super.a();

--- a/lib/widget/webview/WebView.dart
+++ b/lib/widget/webview/WebView.dart
@@ -59,7 +59,7 @@ class WebView extends StatefulWidget {
 
 class _WebViewState extends State<WebView> {
   final Completer<WebViewController> _controller =
-  Completer<WebViewController>();
+      Completer<WebViewController>();
 
   _WebSettings _settings;
 
@@ -76,7 +76,9 @@ class _WebViewState extends State<WebView> {
         child: AndroidView(
           viewType: 'plugins.flutter.io/webview',
           onPlatformViewCreated: _onPlatformViewCreated,
-          gestureRecognizers: widget.gestureRecognizers,
+          gestureRecognizers: widget.gestureRecognizers.map((e) {
+            return Factory<OneSequenceGestureRecognizer>(() => e);
+          }).toSet(),
           // WebView content is not affected by the Android view's layout direction,
           // we explicitly set it here so that the widget doesn't require an ambient
           // directionality.
@@ -101,7 +103,7 @@ class _WebViewState extends State<WebView> {
     super.didUpdateWidget(oldWidget);
     final _WebSettings newSettings = _WebSettings.fromWidget(widget);
     final Map<String, dynamic> settingsUpdate =
-    _settings.updatesMap(newSettings);
+        _settings.updatesMap(newSettings);
     _updateSettings(settingsUpdate);
     _settings = newSettings;
   }


### PR DESCRIPTION
1. 添加analysis_options.yaml 解决 在data-analysis出现的 cast异常和 mixin_inherits_from_not_object异常
2. DemoMixins.dart， mixin 类 修改为 mixin XX on X ， 否则会提示The class 'A2' can't be used as a mixin because it references 'super'
3.  Webview.dart ,  否则会提示类型不匹配 